### PR TITLE
Fix strange zoom issue of ScrollView

### DIFF
--- a/extensions/GUI/CCScrollView/CCScrollView.cpp
+++ b/extensions/GUI/CCScrollView/CCScrollView.cpp
@@ -259,7 +259,7 @@ void ScrollView::setZoomScale(float s)
         }
         else
         {
-            center = _touchPoint;
+            center = this->convertToWorldSpace(_touchPoint);
         }
         
         oldCenter = _container->convertToNodeSpace(center);
@@ -271,7 +271,7 @@ void ScrollView::setZoomScale(float s)
         {
             _delegate->scrollViewDidZoom(this);
         }
-        this->setContentOffset(_container->getPosition() + offset);
+        this->setContentOffset(_container->getPosition() + this->convertToNodeSpace(offset));
     }
 }
 


### PR DESCRIPTION
If we add ScrollView as child of any other view which scale is not 1.0, offset is strange when we do pinch zoom.
It's bug of setZoomScale.
- '_touchPoint' is coordinates of ScrollView's node space, but handled as world space coordinates in setZoomScale
- 'offset' is offset on world space, but handled as offset on node space of ScrollView,
